### PR TITLE
Update links.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 This is a lightweight (12.8 MB!) docker container for: 
 
-https://github.com/bitly/google_auth_proxy
+https://github.com/bitly/oauth2_proxy
 
 Follow their directions to get setup
 
@@ -8,5 +8,5 @@ Follow their directions to get setup
 
 Thanks
 ------
-* The 'gold standard': https://github.com/progrium/logspout
-* copying: https://registry.hub.docker.com/u/texastribune/google-auth-proxy.  This is perfect in its simplicity; it is just that docker container is 37x larger than this one.
+* The 'gold standard': https://github.com/gliderlabs/logspout
+* copying: https://hub.docker.com/r/texastribune/google-auth-proxy/.  This is perfect in its simplicity; it is just that docker container is 37x larger than this one.


### PR DESCRIPTION
Incredibly, 3/3 links have redirected or, in docker hub's case, broken in the last 7 months.
