### PR TITLE
Fix: Use OAUTH2_PROXY_VERSION to determine download URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV OAUTH2_PROXY_VERSION 2.0.1.linux-amd64.go1.4.2
 RUN apk --update add curl
 
 RUN curl -sL -o oauth2_proxy.tar.gz \
-    "https://github.com/bitly/oauth2_proxy/releases/download/v2.0.1/oauth2_proxy-$OAUTH2_PROXY_VERSION.tar.gz" \
+    "https://github.com/bitly/oauth2_proxy/releases/download/v$OAUTH2_PROXY_VERSION/oauth2_proxy-$OAUTH2_PROXY_VERSION.tar.gz" \
   && tar xzvf oauth2_proxy.tar.gz \
   && mv oauth2_proxy-$OAUTH2_PROXY_VERSION/oauth2_proxy /bin/ \
   && chmod +x /bin/oauth2_proxy \


### PR DESCRIPTION
This PR fixes the download URL. It uses $OAUTH2_PROXY_VERSION instead of hardcoding `2.0.1`